### PR TITLE
Add custom color options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,36 @@ will always use `red`. To use random colors for each `debug` instance, pass in
 
 Note: this is only for TTY output.
 
+### `logColor` : <`number`> ###
+
+By default, `debug-caller` will assign the color white(7) to the `log` debug instance. To set a custom color pass in a number (0-7).
+
+* 0: gray
+* 1: red
+* 2: green
+* 3: yellow
+* 4: blue
+* 5: pink
+* 6: light blue
+* 7: white
+
+This option will be ignored if randomColors is set to `true`.
+
+### `errorColor` : <`number`> ###
+
+By default, `debug-caller` will assign the color red(1) to the `error` debug instance. To set a custom color pass in a number (0-7).
+
+* 0: gray
+* 1: red
+* 2: green
+* 3: yellow
+* 4: blue
+* 5: pink
+* 6: light blue
+* 7: white
+
+This option will be ignored if randomColors is set to `true`.
+
 ## API ##
 
 The `debug-caller` module provides two separate instances of `debug` using
@@ -120,4 +150,4 @@ module.exports = function() {
 ## Etc ##
 
 - Licence: [MIT](https://github.com/dylants/debug-caller/blob/master/LICENSE)
-- Dependency Status: [![Dependency Status](https://david-dm.org/dylants/debug-caller.svg)](https://david-dm.org/dylants/debug-caller) 
+- Dependency Status: [![Dependency Status](https://david-dm.org/dylants/debug-caller.svg)](https://david-dm.org/dylants/debug-caller)

--- a/lib/debug-caller.js
+++ b/lib/debug-caller.js
@@ -60,7 +60,9 @@ function logger(appName, options) {
     // merge our default options with the user supplied
     options = xtend({
         depth: 1,
-        randomColors: false
+        randomColors: false,
+        logColor: 7,
+        errorColor: 1,
     }, options);
 
     // get the filename which is used as the namespace for the debug module.
@@ -75,11 +77,11 @@ function logger(appName, options) {
     // this should happen by default, but just to be sure...
     error.log = console.error.bind(console);
 
-    // if we don't want random colors, assign log to white (7) and
-    // error to red (1)
+    // if we don't want random colors, assign log to options.logColor (default: white (7))
+    // and error to options.errorColor (default: red (1))
     if (!options.randomColors) {
-        log.color = 7;
-        error.color = 1;
+        log.color = options.logColor;
+        error.color = options.errorColor;
     }
 
     return {

--- a/test/debug-caller-test.js
+++ b/test/debug-caller-test.js
@@ -71,7 +71,7 @@ describe("The debugCaller library", function() {
             });
         });
 
-        describe("with all options", function() {
+        describe("with all options and randomColors = true", function() {
             var DEPTH;
 
             beforeEach(function() {
@@ -79,7 +79,9 @@ describe("The debugCaller library", function() {
 
                 logger = logger(APP_NAME, {
                     depth: DEPTH,
-                    randomColors: true
+                    randomColors: true,
+                    logColor: 1,
+                    errorColor: 3,
                 });
             });
 
@@ -97,8 +99,43 @@ describe("The debugCaller library", function() {
             });
 
             it("should assign random colors", function() {
-                expect(logger.log.color).toBeUndefined();
-                expect(logger.error.color).toBeUndefined();
+                expect(logger.log.color).toBeDefined();
+                expect(logger.error.color).toBeDefined();
+            });
+        });
+
+        describe("with all options and randomColors = false", function() {
+            var DEPTH, LOG_COLOR, ERROR_COLOR;
+
+            beforeEach(function() {
+                DEPTH = 5;
+                LOG_COLOR = 4;
+                ERROR_COLOR = 3;
+
+                logger = logger(APP_NAME, {
+                    depth: DEPTH,
+                    randomColors: false,
+                    logColor: LOG_COLOR,
+                    errorColor: ERROR_COLOR,
+                });
+            });
+
+            it("should return a log and error function", function() {
+                expect(logger.log).toBeDefined();
+                expect(logger.error).toBeDefined();
+            });
+
+            it("should assign the correct app name", function() {
+                expect(sentAppName).toEqual(APP_NAME);
+            });
+
+            it("should assign the correct depth", function() {
+                expect(sentDepth).toEqual(DEPTH);
+            });
+
+            it("should assign random colors", function() {
+                expect(logger.log.color).toEqual(LOG_COLOR);
+                expect(logger.error.color).toEqual(ERROR_COLOR);
             });
         });
 


### PR DESCRIPTION
This adds options for custom log and error colors. Defaults remain the same. Added test and fixed existing tests as they failed initially.